### PR TITLE
Lazy Configuration with fallback for Ant Task

### DIFF
--- a/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
+++ b/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
@@ -17,11 +17,9 @@ import mpern.sap.commerce.build.util.HybrisPlatform;
 
 public class HybrisAntTask extends JavaExec {
 
-    @Input
-    public MapProperty<String, String> antProperties;
+    private final MapProperty<String, String> antProperties;
 
-    @Input
-    public MapProperty<String, String> fallbackAntProperties;
+    private final MapProperty<String, String> fallbackAntProperties;
 
     private final Property<Boolean> noOp;
 
@@ -104,5 +102,15 @@ public class HybrisAntTask extends JavaExec {
     @Internal
     public Property<Boolean> getNoOp() {
         return noOp;
+    }
+
+    @Input
+    public MapProperty<String, String> getAntProperties() {
+        return antProperties;
+    }
+
+    @Input
+    public MapProperty<String, String> getFallbackAntProperties() {
+        return fallbackAntProperties;
     }
 }

--- a/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
+++ b/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
@@ -18,17 +18,19 @@ import mpern.sap.commerce.build.util.HybrisPlatform;
 public abstract class HybrisAntTask extends JavaExec {
 
     @Input
-    public abstract MapProperty<String, String> antProperties();
+    public MapProperty<String, String> antProperties;
 
     @Input
-    public abstract MapProperty<String, String> fallbackAntProperties();
+    public MapProperty<String, String> fallbackAntProperties;
 
     private final Property<Boolean> noOp;
 
     public HybrisAntTask() {
         super();
         noOp = getProject().getObjects().property(Boolean.class);
-        antProperties().put("maven.update.dbdrivers", "false");
+        fallbackAntProperties = getProject().getObjects().mapProperty(String.class, String.class);
+        antProperties = getProject().getObjects().mapProperty(String.class, String.class);
+        antProperties.put("maven.update.dbdrivers", "false");
     }
 
     @Override
@@ -53,9 +55,9 @@ public abstract class HybrisAntTask extends JavaExec {
                         .getByName(HybrisPlugin.HYBRIS_EXTENSION)).getPlatform();
                 t.systemProperty("ant.home", platform.getAntHome().get().getAsFile());
 
-                Map<String, String> props = t.antProperties().get();
+                Map<String, String> props = t.antProperties.get();
 
-                t.fallbackAntProperties().get().forEach(props::putIfAbsent);
+                t.fallbackAntProperties.get().forEach(props::putIfAbsent);
 
                 props.forEach((k, v) -> t.args("-D" + k + "=" + v));
 
@@ -77,7 +79,7 @@ public abstract class HybrisAntTask extends JavaExec {
      * @param value value of the property
      */
     public void antProperty(String key, String value) {
-        antProperties().put(key, value);
+        antProperties.put(key, value);
     }
 
     /**
@@ -86,7 +88,7 @@ public abstract class HybrisAntTask extends JavaExec {
      * @param antProperties ant properties to use for the target
      */
     public void setAntProperties(Map<String, String> antProperties) {
-        this.antProperties().set(antProperties);
+        this.antProperties.set(antProperties);
     }
 
     @Internal

--- a/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
+++ b/src/main/java/mpern/sap/commerce/build/tasks/HybrisAntTask.java
@@ -15,7 +15,7 @@ import mpern.sap.commerce.build.HybrisPlugin;
 import mpern.sap.commerce.build.HybrisPluginExtension;
 import mpern.sap.commerce.build.util.HybrisPlatform;
 
-public abstract class HybrisAntTask extends JavaExec {
+public class HybrisAntTask extends JavaExec {
 
     @Input
     public MapProperty<String, String> antProperties;
@@ -89,6 +89,16 @@ public abstract class HybrisAntTask extends JavaExec {
      */
     public void setAntProperties(Map<String, String> antProperties) {
         this.antProperties.set(antProperties);
+    }
+
+    /**
+     * Add a new runtime property to configure the ant target
+     *
+     * @param key   key of the property
+     * @param value value of the property
+     */
+    public void fallbackAntProperty(String key, String value) {
+        fallbackAntProperties.put(key, value);
     }
 
     @Internal


### PR DESCRIPTION
Currently, the Ant Task is evaluated during the Configuration phase,
and it is not possible to add a dynamic configuration.
With this change the ant properties are lazily evaluated, which allows to eg use outcomes of other tasks.
Additionally, we provide a fallback - if a property is not set.
This allows to define placeholders within the project.properties and a fallback if needed. Useful when you want to add the jacoco agent from gradle to the standalone.javaoptions.

This is just a proposal, i am not sure if this is actually desirable for this project