### PR TITLE
Make Tests Windows compatible

### DIFF
--- a/src/functionalTest/groovy/mpern/sap/commerce/build/CCv2Tests.groovy
+++ b/src/functionalTest/groovy/mpern/sap/commerce/build/CCv2Tests.groovy
@@ -173,7 +173,7 @@ class CCv2Tests extends Specification {
         def local = new XmlSlurper().parse(localExtensions.toFile())
 
         then: "plugin patches localextensions.xml to load cloud extension pack first"
-        local.extensions.path[0].'@dir' == '${HYBRIS_BIN_DIR}/../../cloud-extension-pack'
+        local.extensions.path[0].'@dir' == Paths.get('${HYBRIS_BIN_DIR}/../../cloud-extension-pack')
         local.extensions.path[1].'@dir' == '${HYBRIS_BIN_DIR}'
         cepDirResolvesCorrectly(local.extensions.path[0].'@dir'.toString())
     }

--- a/src/main/java/mpern/sap/commerce/ccv2/tasks/PatchLocalExtensions.java
+++ b/src/main/java/mpern/sap/commerce/ccv2/tasks/PatchLocalExtensions.java
@@ -1,5 +1,6 @@
 package mpern.sap.commerce.ccv2.tasks;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,7 +42,7 @@ public class PatchLocalExtensions extends DefaultTask {
         Path cepPath = cepFolder.get().getAsFile().toPath();
 
         Path relativize = hybrisBin.relativize(cepPath);
-        String cepPathString = "${HYBRIS_BIN_DIR}/" + relativize.toString();
+        String cepPathString = "${HYBRIS_BIN_DIR}"+ File.separator + relativize.toString();
 
         patchLocalExtensions(cepPathString);
     }

--- a/src/main/java/mpern/sap/commerce/ccv2/tasks/PatchLocalExtensions.java
+++ b/src/main/java/mpern/sap/commerce/ccv2/tasks/PatchLocalExtensions.java
@@ -42,7 +42,7 @@ public class PatchLocalExtensions extends DefaultTask {
         Path cepPath = cepFolder.get().getAsFile().toPath();
 
         Path relativize = hybrisBin.relativize(cepPath);
-        String cepPathString = "${HYBRIS_BIN_DIR}"+ File.separator + relativize.toString();
+        String cepPathString = "${HYBRIS_BIN_DIR}" + File.separator + relativize.toString();
 
         patchLocalExtensions(cepPathString);
     }


### PR DESCRIPTION
Tests have been failing on Windows due to path separators.
This changes rely on dynamic paths, and is using the
`File.separator` to determine what should be used.