### PR TITLE
Task dependency improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-TBD
+- Task ordering improvements.
+
+## [4.1.0]
+
+- Add support for JDK21 version of SAP Commerce
+- Dependency Updates
 
 ## [4.0.0] 2023-07-31
 
@@ -431,7 +436,8 @@ Shout out to [@corneleberle] for providing the fix.
 
 :tada: Initial release :tada:
 
-[Unreleased]: https://github.com/SAP/commerce-gradle-plugin/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/SAP/commerce-gradle-plugin/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/SAP/commerce-gradle-plugin/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/SAP/commerce-gradle-plugin/compare/v3.10.0...v4.0.0
 [3.10.0]: https://github.com/SAP/commerce-gradle-plugin/compare/v3.9.1...v3.10.0
 [3.9.1]: https://github.com/SAP/commerce-gradle-plugin/compare/v3.9.0...v3.9.1

--- a/cloud-plugin/src/main/java/mpern/sap/commerce/ccv2/CloudV2Plugin.java
+++ b/cloud-plugin/src/main/java/mpern/sap/commerce/ccv2/CloudV2Plugin.java
@@ -118,6 +118,7 @@ public class CloudV2Plugin implements Plugin<Project> {
                         if (finalI > 0) {
                             t.mustRunAfter(String.format("addonInstall_%d", (finalI - 1)));
                         }
+                        t.mustRunAfter("unpackPlatform", "unpackPlatformSparse");
                         t.args("addoninstall");
                         t.antProperty("addonnames", addonParameter);
                         t.antProperty("addonStorefront." + addonInstall.template, storefrontParameter);


### PR DESCRIPTION
Depending on Parralelism in Build, the initial setup will fail, if the Plugin tries addon install too early.

I think that can be fixed, by making it run only after unpackPlatform(Sparse)